### PR TITLE
delete feature for removing campgrounds

### DIFF
--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -9,3 +9,7 @@
 .thumbnail .caption-full {
     padding: 9px;
 }
+
+#delete-form {
+    display: inline;
+}

--- a/routes/campgrounds.js
+++ b/routes/campgrounds.js
@@ -67,18 +67,30 @@ router.get("/:id/edit", function (req, res) {
     });
 });
 
+// UPDATE CAMPGROUND ROUTE
 router.put("/:id", function(req, res) {
     //find and update the correct campground
     Campground.findByIdAndUpdate(req.params.id, req.body.campground, function(err, updatedCampground) {
         if(err) {
             res.redirect("/campgrounds");
         } else {
+            //redirect somewhere(show page)
             res.redirect("/campgrounds/" + req.params.id);
         }
     });
-    //redirect somewhere(show page)
 });
-// UPDATE CAMPGROUND ROUTE
+
+// DESTROY CAMPGROUND ROUTE
+router.delete("/:id", function(req, res) {
+    Campground.findByIdAndRemove(req.params.id, function(err) {
+        if(err) {
+            res.redirect("/campgrounds");
+        } else {
+            res.redirect("/campgrounds");
+        }
+    });
+});
+
 // middleware
 function isLoggedIn(req, res, next) {
     if(req.isAuthenticated()) {

--- a/views/campgrounds/show.ejs
+++ b/views/campgrounds/show.ejs
@@ -21,6 +21,9 @@
                         <em>Submitted By <%= campground.author.username %></em>
                     </p>
                     <a class="btn btn-warning" href="/campgrounds/<%= campground._id %>/edit">Edit</a>
+                    <form id="delete-form" action="/campgrounds/<%= campground._id %>?_method=DELETE" method=POST>
+                        <button class="btn btn-danger">Delete</button>
+                    </form>
                 </div>
             </div>
             <div class="well">


### PR DESCRIPTION
This feature allows the deletion of a campground.  A 'DESTROY'  route is added.  Then on the show page, 'show.ejs', a form is added to contain a 'Delete' button.  It is also styled in CSS to be inline.