### PR TITLE
edit and delete feature for authorized user

### DIFF
--- a/routes/campgrounds.js
+++ b/routes/campgrounds.js
@@ -57,18 +57,14 @@ router.get("/:id", function(req, res) {
 });
 
 // EDIT CAMPGROUND ROUTE
-router.get("/:id/edit", function (req, res) {
+router.get("/:id/edit", checkCampgroundOwnership, function (req, res) {
     Campground.findById(req.params.id, function(err, foundCampground) {
-        if(err) {
-            res.redirect("/campgrounds");
-        } else {
-            res.render("campgrounds/edit", {campground: foundCampground});
-        }
+        res.render("campgrounds/edit", {campground: foundCampground});
     });
 });
 
 // UPDATE CAMPGROUND ROUTE
-router.put("/:id", function(req, res) {
+router.put("/:id", checkCampgroundOwnership, function(req, res) {
     //find and update the correct campground
     Campground.findByIdAndUpdate(req.params.id, req.body.campground, function(err, updatedCampground) {
         if(err) {
@@ -81,7 +77,7 @@ router.put("/:id", function(req, res) {
 });
 
 // DESTROY CAMPGROUND ROUTE
-router.delete("/:id", function(req, res) {
+router.delete("/:id", checkCampgroundOwnership, function(req, res) {
     Campground.findByIdAndRemove(req.params.id, function(err) {
         if(err) {
             res.redirect("/campgrounds");
@@ -97,6 +93,25 @@ function isLoggedIn(req, res, next) {
         return next();
     }
     res.redirect("/login");
+}
+
+function checkCampgroundOwnership(req, res, next) {
+        if(req.isAuthenticated()) {
+        Campground.findById(req.params.id, function(err, foundCampground) {
+        if(err) {
+            res.redirect("back");
+        } else {
+             //does user own the campground?
+             if (foundCampground.author.id.equals(req.user._id)) {
+                 next();
+             } else {
+                 res.redirect("back");
+             }
+        }
+    });
+    } else {
+        res.redirect("back");
+    }
 }
 
 module.exports = router;


### PR DESCRIPTION
This feature is for authorization, so only an authorized user can edit and delete a campground.  In the 'app.js' file, created a middleware called `checkCampgroundOwnership` to see if a user is both authenticated and matches the id of the campground author.  Then added this middleware to the Edit Route, Update Route, and Destroy Route.