### PR TITLE
show or hide buttons depending if user is authorized

### DIFF
--- a/views/campgrounds/show.ejs
+++ b/views/campgrounds/show.ejs
@@ -20,10 +20,12 @@
                     <p>
                         <em>Submitted By <%= campground.author.username %></em>
                     </p>
+                    <% if (currentUser && campground.author.id.equals(currentUser._id)) { %>
                     <a class="btn btn-warning" href="/campgrounds/<%= campground._id %>/edit">Edit</a>
                     <form id="delete-form" action="/campgrounds/<%= campground._id %>?_method=DELETE" method=POST>
                         <button class="btn btn-danger">Delete</button>
                     </form>
+                    <% } %>
                 </div>
             </div>
             <div class="well">


### PR DESCRIPTION
This is for authorization to determine whether to show the 'edit' and 'delete' buttons depending if the user is authorized.  Only the author of the campground has access to these.  In the Show template, the 'show.ejs' file, added an `if` statement to check someone is a current user AND is the campground author.  This `if` statement is wrapped around these buttons.