### PR TITLE
authorization of edit and delete comments

### DIFF
--- a/routes/comments.js
+++ b/routes/comments.js
@@ -45,7 +45,7 @@ router.post("/", isLoggedIn, function (req, res){
 });
 
 // Comment Edit Route
-router.get("/:comment_id/edit", function(req, res) {
+router.get("/:comment_id/edit", checkCommentOwnership, function(req, res) {
     Comment.findById(req.params.comment_id, function(err, foundComment) {
         if(err) {
             res.redirect("back");
@@ -56,7 +56,7 @@ router.get("/:comment_id/edit", function(req, res) {
 });
 
 // Comment Update
-router.put("/:comment_id", function(req, res) {
+router.put("/:comment_id", checkCommentOwnership, function(req, res) {
     Comment.findByIdAndUpdate(req.params.comment_id, req.body.comment, function(err, updatedComment) {
         if(err) {
             res.redirect("back");
@@ -67,7 +67,7 @@ router.put("/:comment_id", function(req, res) {
 });
 
 // Comment Destroy Route
-router.delete("/:comment_id", function(req, res) {
+router.delete("/:comment_id", checkCommentOwnership, function(req, res) {
     // findByIdAndRemove
     Comment.findByIdAndRemove(req.params.comment_id, function(err) {
         if (err) {
@@ -84,6 +84,25 @@ function isLoggedIn(req, res, next) {
         return next();
     }
     res.redirect("/login");
+}
+
+function checkCommentOwnership(req, res, next) {
+        if(req.isAuthenticated()) {
+        Comment.findById(req.params.comment_id, function(err, foundComment) {
+        if(err) {
+            res.redirect("back");
+        } else {
+             //does user own the comment?
+             if (foundComment.author.id.equals(req.user._id)) {
+                 next();
+             } else {
+                 res.redirect("back");
+             }
+        }
+    });
+    } else {
+        res.redirect("back");
+    }
 }
 
 module.exports = router;

--- a/views/campgrounds/show.ejs
+++ b/views/campgrounds/show.ejs
@@ -41,6 +41,7 @@
                             <p>
                                 <%= comment.text %>
                             </p>
+                        <% if (currentUser && comment.author.id.equals(currentUser._id)) { %>
                             <a class="btn btn-xs btn-warning" 
                                 href="/campgrounds/<%= campground._id %>/comments/<%= comment._id %>/edit">
                                 Edit
@@ -48,6 +49,7 @@
                             <form class="delete-form" action="/campgrounds/<%= campground._id %>/comments/<%= comment._id %>?_method=DELETE" method=POST>
                                 <input type="submit" class="btn btn-xs btn-danger" value="Delete">
                             </form>
+                        <% }; %>
                         </div>
                     </div>
                 <% }) %>


### PR DESCRIPTION
Set up to allow only user to edit comments.  In `comments.js` file, under the `//Comment Edit Route`, copied over the middleware from the `campgrounds.js` to this file.  Then adjusted it to incorporate 'Comment' instead of `Campground` under the section of `//Middleware`.  Then added `checkCampgroundOwnership` middleware to the `//Comment Edit Route`. 

The middleware was then added to the `//Comment Update` section and the `//Comment Destroy Section`.  Then in the `show.ejs' file, added an `if` statement to only show buttons if user is the author.