### PR TITLE
refactor middleware into seperate directory

### DIFF
--- a/middleware/index.js
+++ b/middleware/index.js
@@ -1,0 +1,53 @@
+const Campground = require("../models/campground");
+const Comment = require("../models/comment");
+
+// All the middleware goes here
+
+const middlewareObj = {};
+
+middlewareObj.checkCampgroundOwnership = function(req, res, next) {
+    if(req.isAuthenticated()) {
+        Campground.findById(req.params.id, function(err, foundCampground) {
+            if(err) {
+                res.redirect("back");
+            } else {
+                //does user own the campground?
+            if (foundCampground.author.id.equals(req.user._id)) {
+                next();
+            } else {
+                res.redirect("back");
+            }
+        }
+    });
+    } else {
+        res.redirect("back");
+    }
+};
+
+middlewareObj.checkCommentOwnership = function(req, res, next) {
+    if(req.isAuthenticated()) {
+        Comment.findById(req.params.comment_id, function(err, foundComment) {
+            if(err) {
+                res.redirect("back");
+            } else {
+            //does user own the comment?
+            if (foundComment.author.id.equals(req.user._id)) {
+                next();
+            } else {
+                res.redirect("back");
+            }
+        }
+    });
+    } else {
+        res.redirect("back");
+    }
+};
+
+middlewareObj.isLoggedIn = function(req, res, next) {
+    if(req.isAuthenticated()) {
+        return next();
+    }
+    res.redirect("/login");
+};
+
+module.exports = middlewareObj;

--- a/routes/campgrounds.js
+++ b/routes/campgrounds.js
@@ -1,6 +1,7 @@
 const express = require("express");
 const router = express.Router();
 const Campground = require("../models/campground");
+const middleware = require("../middleware");
 
 //INDEX - show all campgrounds
 router.get("/", function(req, res) {
@@ -15,7 +16,7 @@ router.get("/", function(req, res) {
 });
 
 //CREATE - add new campground to DB
-router.post("/", isLoggedIn, function(req, res) {
+router.post("/", middleware.isLoggedIn, function(req, res) {
     //get data from form and add to campgrounds array
     const name = req.body.name;
     const image = req.body.image;
@@ -38,7 +39,7 @@ router.post("/", isLoggedIn, function(req, res) {
 });
 
 //NEW - show form to create new campground
-router.get("/new", isLoggedIn, function(req, res) {
+router.get("/new", middleware.isLoggedIn, function(req, res) {
     res.render("campgrounds/new");
 });
 
@@ -57,14 +58,14 @@ router.get("/:id", function(req, res) {
 });
 
 // EDIT CAMPGROUND ROUTE
-router.get("/:id/edit", checkCampgroundOwnership, function (req, res) {
+router.get("/:id/edit", middleware.checkCampgroundOwnership, function (req, res) {
     Campground.findById(req.params.id, function(err, foundCampground) {
         res.render("campgrounds/edit", {campground: foundCampground});
     });
 });
 
 // UPDATE CAMPGROUND ROUTE
-router.put("/:id", checkCampgroundOwnership, function(req, res) {
+router.put("/:id", middleware.checkCampgroundOwnership, function(req, res) {
     //find and update the correct campground
     Campground.findByIdAndUpdate(req.params.id, req.body.campground, function(err, updatedCampground) {
         if(err) {
@@ -77,7 +78,7 @@ router.put("/:id", checkCampgroundOwnership, function(req, res) {
 });
 
 // DESTROY CAMPGROUND ROUTE
-router.delete("/:id", checkCampgroundOwnership, function(req, res) {
+router.delete("/:id", middleware.checkCampgroundOwnership, function(req, res) {
     Campground.findByIdAndRemove(req.params.id, function(err) {
         if(err) {
             res.redirect("/campgrounds");
@@ -86,33 +87,6 @@ router.delete("/:id", checkCampgroundOwnership, function(req, res) {
         }
     });
 });
-
-// middleware
-function isLoggedIn(req, res, next) {
-    if(req.isAuthenticated()) {
-        return next();
-    }
-    res.redirect("/login");
-}
-
-function checkCampgroundOwnership(req, res, next) {
-        if(req.isAuthenticated()) {
-        Campground.findById(req.params.id, function(err, foundCampground) {
-        if(err) {
-            res.redirect("back");
-        } else {
-             //does user own the campground?
-             if (foundCampground.author.id.equals(req.user._id)) {
-                 next();
-             } else {
-                 res.redirect("back");
-             }
-        }
-    });
-    } else {
-        res.redirect("back");
-    }
-}
 
 module.exports = router;
 

--- a/routes/comments.js
+++ b/routes/comments.js
@@ -1,10 +1,11 @@
 const express  = require("express");
 const router   = express.Router({mergeParams: true});
-var Campground = require("../models/campground");
-var Comment    = require("../models/comment");
+const Campground = require("../models/campground");
+const Comment    = require("../models/comment");
+const middleware = require("../middleware");
 
 // Comments New
-router.get("/new", isLoggedIn, function (req, res) {
+router.get("/new", middleware.isLoggedIn, function (req, res) {
     //find campground by id
     Campground.findById(req.params.id, function (err, campground) {
         if (err) {
@@ -13,11 +14,10 @@ router.get("/new", isLoggedIn, function (req, res) {
             res.render("comments/new", {campground: campground});
         }
     });
-    
 });
 
 // Comments Create
-router.post("/", isLoggedIn, function (req, res){
+router.post("/", middleware.isLoggedIn, function (req, res){
     //lookup campground using id
     Campground.findById(req.params.id, function (err, campground) {
         if (err) {
@@ -45,7 +45,7 @@ router.post("/", isLoggedIn, function (req, res){
 });
 
 // Comment Edit Route
-router.get("/:comment_id/edit", checkCommentOwnership, function(req, res) {
+router.get("/:comment_id/edit", middleware.checkCommentOwnership, function(req, res) {
     Comment.findById(req.params.comment_id, function(err, foundComment) {
         if(err) {
             res.redirect("back");
@@ -56,7 +56,7 @@ router.get("/:comment_id/edit", checkCommentOwnership, function(req, res) {
 });
 
 // Comment Update
-router.put("/:comment_id", checkCommentOwnership, function(req, res) {
+router.put("/:comment_id", middleware.checkCommentOwnership, function(req, res) {
     Comment.findByIdAndUpdate(req.params.comment_id, req.body.comment, function(err, updatedComment) {
         if(err) {
             res.redirect("back");
@@ -67,7 +67,7 @@ router.put("/:comment_id", checkCommentOwnership, function(req, res) {
 });
 
 // Comment Destroy Route
-router.delete("/:comment_id", checkCommentOwnership, function(req, res) {
+router.delete("/:comment_id", middleware.checkCommentOwnership, function(req, res) {
     // findByIdAndRemove
     Comment.findByIdAndRemove(req.params.comment_id, function(err) {
         if (err) {
@@ -77,32 +77,5 @@ router.delete("/:comment_id", checkCommentOwnership, function(req, res) {
         }
     });
 });
-
-// middleware
-function isLoggedIn(req, res, next) {
-    if(req.isAuthenticated()) {
-        return next();
-    }
-    res.redirect("/login");
-}
-
-function checkCommentOwnership(req, res, next) {
-        if(req.isAuthenticated()) {
-        Comment.findById(req.params.comment_id, function(err, foundComment) {
-        if(err) {
-            res.redirect("back");
-        } else {
-             //does user own the comment?
-             if (foundComment.author.id.equals(req.user._id)) {
-                 next();
-             } else {
-                 res.redirect("back");
-             }
-        }
-    });
-    } else {
-        res.redirect("back");
-    }
-}
 
 module.exports = router;


### PR DESCRIPTION
This refactors the middleware so its all in a separate directory.  A new directory called `middleware` was created.  Inside of this a new file `index.js` was created.  An object called `middlewareObj` was created in this file.  
The middleware was cut from `campgrounds.js` and `comments.js` and pasted into the new file. There are three in total: `checkCampgroundOwnership`, `checkCommentOwnership`, and `isLoggedIn`, which then had attached to them `middleware.`.  Each of the `.js` files were set to `require` this middleware file.  Then the new file was set to `require` the `models/campground` and the `models/comment`.